### PR TITLE
Converging nozzle geom with breaking tile size

### DIFF
--- a/Exec/SodPlusSphere/converging_nozzle.inp
+++ b/Exec/SodPlusSphere/converging_nozzle.inp
@@ -1,0 +1,73 @@
+amrex.fpe_trap_invalid = 1
+amrex.fpe_trap_zero = 1
+amrex.fpe_trap_overflow = 1
+
+max_step  = 1
+stop_time = 0.2
+
+geometry.is_periodic = 0 0 0
+geometry.coord_sys   = 0  # 0 => cart, 1 => RZ  2=>spherical
+geometry.prob_lo     =  0.0 -6 -6
+geometry.prob_hi     =  18 6 6
+amr.n_cell           =  72 48 48
+
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+# 0 = Interior           3 = Symmetry
+# 1 = Inflow             4 = SlipWall
+# 2 = Outflow            5 = NoSlipWall
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+CAMR.lo_bc       =  Outflow  SlipWall   SlipWall
+CAMR.hi_bc       =  Outflow  SlipWall   SlipWall
+
+CAMR.cfl = 0.3  # cfl number for hyperbolic system
+
+CAMR.do_mol = 1
+
+CAMR.v = 2
+amr.v = 1
+
+CAMR.sum_interval = 1
+
+CAMR.redistribution_type = FluxRedist
+CAMR.redistribution_type = StateRedist
+
+# LOAD BALANCE
+amr.loadbalance_with_workestimates = 0
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.regrid_int      = 2 2 2 2 # how often to regrid
+amr.blocking_factor = 8
+amr.max_grid_size   = 64
+amr.n_error_buf     = 0 0 0 0 # number of buffer cells in error est
+
+# CHECKPOINT FILES
+amr.checkpoint_files_output = 0
+amr.check_file              = chk    # root name of checkpoint file
+amr.check_int               = 100    # number of timesteps between checkpoints
+
+# PLOTFILES
+amr.plot_files_output = 1
+amr.plot_file         = plt     # root name of plotfile
+amr.plot_int          = 1      # number of timesteps between plotfiles
+amr.derive_plot_vars  = x_velocity y_velocity z_velocity vfrac
+
+# EB
+CAMR.geometry = "converging-nozzle"
+converging_nozzle.d_inlet = 10.0
+converging_nozzle.l_inlet = 4.5
+converging_nozzle.l_nozzle = 9.0
+converging_nozzle.d_exit = 7.0710678119
+eb2.small_volfrac=1.e-6
+# problem specific parameter
+prob.rho_l = 3.6737153092795505
+prob.u_l   = 3.8260444105770732
+prob.p_l   = 22.613625000000006
+prob.rho_r = 1.0
+prob.u_r   = 0.0
+prob.p_r   = 2.5
+prob.interface = -10.0
+
+CAMR.hydro_tile_size=1024 8 8

--- a/Source/EB/Make.package
+++ b/Source/EB/Make.package
@@ -4,6 +4,7 @@ CEXE_sources += eb_cylinder.cpp
 CEXE_sources += eb_regular.cpp
 CEXE_sources += eb_sphere.cpp
 CEXE_sources += eb_plane.cpp
+CEXE_sources += eb_converging_nozzle.cpp
 CEXE_sources += writeEBsurface.cpp
 
 CEXE_headers += eb_if.H

--- a/Source/EB/eb_converging_nozzle.cpp
+++ b/Source/EB/eb_converging_nozzle.cpp
@@ -24,7 +24,7 @@ void make_eb_converging_nozzle (const Geometry& geom, int required_coarsening_le
   pp.query("l_inlet", l_inlet);
   pp.query("l_nozzle", l_nozzle);
   pp.query("d_exit", d_exit);
-  
+
   amrex::EB2::CylinderIF main(
     0.5 * d_inlet, 0,
     {AMREX_D_DECL(static_cast<amrex::Real>(0.5 * l_inlet), 0, 0)}, true);

--- a/Source/EB/eb_converging_nozzle.cpp
+++ b/Source/EB/eb_converging_nozzle.cpp
@@ -1,0 +1,55 @@
+#include <AMReX_EB2.H>
+#include <AMReX_EB2_IF.H>
+#include <AMReX_ParmParse.H>
+
+#include <algorithm>
+#include <CAMR.H>
+
+using namespace amrex;
+
+/********************************************************************************
+ *                                                                              *
+ * Function to create a converging nozzle EB.                                   *
+ *                                                                              *
+ ********************************************************************************/
+void make_eb_converging_nozzle (const Geometry& geom, int required_coarsening_level)
+{
+  amrex::Real d_inlet = 8;
+  amrex::Real l_inlet = 24;
+  amrex::Real l_nozzle = 5;
+  amrex::Real d_exit = 5;
+
+  amrex::ParmParse pp("converging_nozzle");
+  pp.query("d_inlet", d_inlet);
+  pp.query("l_inlet", l_inlet);
+  pp.query("l_nozzle", l_nozzle);
+  pp.query("d_exit", d_exit);
+  
+  amrex::EB2::CylinderIF main(
+    0.5 * d_inlet, 0,
+    {AMREX_D_DECL(static_cast<amrex::Real>(0.5 * l_inlet), 0, 0)}, true);
+
+  amrex::Real slope_nozzle =
+    (0.5 * d_inlet - 0.5 * d_exit) / l_nozzle;
+  amrex::Real norm = -1.0 / slope_nozzle;
+  amrex::Real nmag = std::sqrt(1 + 1 / (norm * norm));
+  amrex::EB2::PlaneIF nozzle_plane(
+    {AMREX_D_DECL(0, 0, 0)},
+    {AMREX_D_DECL(
+      static_cast<amrex::Real>(1.0 / nmag), slope_nozzle / nmag, 0.0)},
+    true);
+  auto nozzle = amrex::EB2::translate(
+    amrex::EB2::rotate(amrex::EB2::lathe(nozzle_plane), 90 * M_PI / 180, 1),
+    {AMREX_D_DECL(
+      l_inlet + static_cast<amrex::Real>(0.5 * d_inlet / slope_nozzle),
+      0, 0)});
+
+  amrex::EB2::CylinderIF exit(
+    0.5 * d_exit, 0, {AMREX_D_DECL(l_inlet + l_nozzle, 0, 0)},
+    true);
+  auto nozzle_exit = amrex::EB2::makeIntersection(nozzle, exit);
+
+  auto polys = amrex::EB2::makeUnion(main, nozzle_exit);
+  auto gshop = amrex::EB2::makeShop(polys);
+  EB2::Build(gshop, geom, required_coarsening_level, required_coarsening_level);
+}

--- a/Source/EB/embedded_boundaries.cpp
+++ b/Source/EB/embedded_boundaries.cpp
@@ -10,6 +10,7 @@ void make_eb_sphere(const Geometry& geom, int required_coarsening_level);
 void make_eb_box(const Geometry& geom, int required_coarsening_level);
 void make_eb_cylinder(const Geometry& geom, int required_coarsening_level);
 void make_eb_plane(const Geometry& geom, int required_coarsening_level, amrex::Real time);
+void make_eb_converging_nozzle(const Geometry& geom, int required_coarsening_level);
 
 void
 initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
@@ -49,6 +50,10 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
     else if(geom_type == "plane")
     {
         make_eb_plane(geom, max_coarsening_level, time);
+    }
+    else if(geom_type == "converging-nozzle")
+    {
+        make_eb_converging_nozzle(geom, max_coarsening_level);
     }
     else
     {


### PR DESCRIPTION
This input file (which uses the added geometry) causes the following NaN:
```
frame #0: 0x000000010083fc24 CAMR3d.llvm.DEBUG.EB.ex`amrex::MLStateRedistribute(amrex::Box const&, int, amrex::Array4<double> const&, amrex::Array4<double> const&, amrex::Array4<amrex::EBCellFlag const> const&, amrex::Array4<double const> const&, amrex::Array4<double const> const&, amrex::Array4<double const> const&, amrex::Array4<double const> const&, amrex::Array4<double const> const&, amrex::BCRec const*, amrex::Array4<int const> const&, amrex::Array4<double const> const&, amrex::Array4<double const> const&, amrex::Array4<double const> const&, amrex::Array4<double const> const&, amrex::Geometry const&, int, amrex::Array4<double> const&, amrex::Array4<int const> const&, int, amrex::Array4<double> const&, amrex::Array4<int const> const&, int, double, int)::$_2::operator()(int, int, int) const at AMReX_EB_Slopes_3D_K.H:371:40
   368 	    {
   369 	        if (!flag(i+ii,j+jj,k+kk).isCovered() && !(ii==0 && jj==0 && kk==0))
   370 	        {
-> 371 	            A[lc][0] = amrex::Real(ii) + ccent(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
   372 	            A[lc][1] = amrex::Real(jj) + ccent(i+ii,j+jj,k+kk,1) - ccent(i,j,k,1);
   373 	            A[lc][2] = amrex::Real(kk) + ccent(i+ii,j+jj,k+kk,2) - ccent(i,j,k,2);
   374 	        }
```

`ccent(i+ii,j+jj,k+kk,0)` is NaN


Other diagnostics:
```
amr.n_cell           =  72 48 48
```

```
(lldb) print i
p(int) $0 = 48
(lldb) print j
(int) $1 = 22
(lldb) print k
(int) $2 = 8
```
bxg1, bxg2, bxg3 are:
```
Box sizes: ((39,15,-1) (72,24,8) (0,0,0)) | ((38,14,-2) (73,25,9) (0,0,0)) | ((37,13,-3) (74,26,10) (0,0,0))
```

Importantly, this doesn't break if we change the `hydro_tile_size` to be bigger than `1024 8 8` (as set in the input file). E.g. `1024 16 16` works.