### PR TITLE
Disable Scheduled GitHub Actions on Forks

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   cuda_eb_2d:
+    if: ${{ github.repository == 'AMReX-Codes/CAMR' || github.event_name != 'schedule' }}
     name: CUDA EB 2D
     runs-on: ubuntu-20.04
     steps:
@@ -56,6 +57,7 @@ jobs:
         du -hs ~/.cache/ccache
 
   cuda_no_eb_2d:
+    if: ${{ github.repository == 'AMReX-Codes/CAMR' || github.event_name != 'schedule' }}
     name: CUDA NO EB 2D
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   gcc_eb_3d:
+    if: ${{ github.repository == 'AMReX-Codes/CAMR' || github.event_name != 'schedule' }}
     name: GCC EB 3D
     runs-on: ubuntu-latest
     steps:
@@ -66,6 +67,7 @@ jobs:
         mpiexec -n 2 ./CAMR3d.gnu.MPI.EB.ex inputs max_step=3
 
   gcc_no_eb_3d:
+    if: ${{ github.repository == 'AMReX-Codes/CAMR' || github.event_name != 'schedule' }}
     name: GCC NO EB 3D
     runs-on: ubuntu-latest
     steps:
@@ -119,6 +121,7 @@ jobs:
         mpiexec -n 2 ./CAMR3d.gnu.MPI.ex inputs-x max_step=3
 
   gcc_eb_2d:
+    if: ${{ github.repository == 'AMReX-Codes/CAMR' || github.event_name != 'schedule' }}
     name: GCC EB 2D
     runs-on: ubuntu-latest
     steps:
@@ -173,6 +176,7 @@ jobs:
         ./CAMR2d.gnu.OMP.EB.ex inputs max_step=10
 
   gcc_no_eb_2d:
+    if: ${{ github.repository == 'AMReX-Codes/CAMR' || github.event_name != 'schedule' }}
     name: GCC NO EB 2D
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   hip_eb_3d:
+    if: ${{ github.repository == 'AMReX-Codes/CAMR' || github.event_name != 'schedule' }}
     name: HIP EB 3D
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   sycl_no_eb_3d:
+    if: ${{ github.repository == 'AMReX-Codes/CAMR' || github.event_name != 'schedule' }}
     name: SYCL NO EB 3D
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The default branch on a fork is often out of sync with the main repo, resulting in failures in scheduled actions. This disables scheduled actions on forks. Note that `push` and `pull_request` still trigger GitHub actions on forks. If one wants to disable it entirely in their fork, follow the instruction in the link below.

https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow?tool=webui#disabling-a-workflow